### PR TITLE
Remove unneeded route name , to avoid console warning about unneeded …

### DIFF
--- a/gene-network/src/main/frontend/src/components/PhenotypeSelectionContainer.vue
+++ b/gene-network/src/main/frontend/src/components/PhenotypeSelectionContainer.vue
@@ -25,8 +25,17 @@
       }
     },
     created: function () {
-      const entityTypeId = this.$route.params.entityTypeId
-      this.$store.dispatch(GET_PATIENT, entityTypeId)
+      this.updatePatient()
+    },
+    watch: {
+      // call again the method if the route changes
+      '$route': 'updatePatient'
+    },
+    methods: {
+      updatePatient () {
+        const entityTypeId = this.$route.params.entityTypeId
+        this.$store.dispatch(GET_PATIENT, entityTypeId)
+      }
     }
   }
 </script>

--- a/gene-network/src/main/frontend/src/router/index.js
+++ b/gene-network/src/main/frontend/src/router/index.js
@@ -25,7 +25,6 @@ export default new VueRouter({
     },
     {
       path: '/patients',
-      name: 'patients',
       component: PatientsContainer,
       children: [{
         path: ':entityTypeId',

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     </scm>
 
     <properties>
-        <molgenis.dependency>4.0.0</molgenis.dependency>
+        <molgenis.dependency>4.1.0-SNAPSHOT</molgenis.dependency>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <slf4j.version>1.7.12</slf4j.version>
         <logback.version>1.1.3</logback.version>


### PR DESCRIPTION
Remove unneeded route name, to avoid console warning about unneeded route name at start up

+

Use platform 4.1.0 snapshot as backend , as we need to be able to set the package name