### PR TITLE
Reset the selected phenotypes on route change

### DIFF
--- a/gene-network/src/main/frontend/src/components/PhenotypeSelectionContainer.vue
+++ b/gene-network/src/main/frontend/src/components/PhenotypeSelectionContainer.vue
@@ -20,7 +20,7 @@
           // Sort variants on GeneNetwork score before passing it to variant table
           // TODO Relevant variants and all variants
           const variants = this.$store.state.variants.slice()
-          return variants.sort((a, b) => Number(b.totalScore) - Number(a.totalScore))
+          return variants.sort(this.sortVariants)
         }
       }
     },
@@ -35,6 +35,13 @@
       updatePatient () {
         const entityTypeId = this.$route.params.entityTypeId
         this.$store.dispatch(GET_PATIENT, entityTypeId)
+      },
+      sortVariants (a, b) {
+        // default sort in case of no score
+        if (a.totalScore === undefined || b.totalScore === undefined) {
+          return b.Gene_Name.localeCompare(a.Gene_Name)
+        }
+        return b.totalScore - a.totalScore
       }
     }
   }

--- a/gene-network/src/main/frontend/src/store/actions.js
+++ b/gene-network/src/main/frontend/src/store/actions.js
@@ -107,7 +107,7 @@ export default {
    *
    * @param commit commits:
    * @param state current state of the application
-   * @param phenotype
+   * @param {!object} phenotypeFilter
    */
   [COMPUTE_SCORE] ({commit, state}, phenotypeFilter) {
     const matrixEntityId = state.matrixEntityId

--- a/gene-network/src/main/frontend/src/store/mutations.js
+++ b/gene-network/src/main/frontend/src/store/mutations.js
@@ -10,6 +10,7 @@ export const TOGGLE_ACTIVE_PHENOTYPE_FILTERS = '__TOGGLE_ACTIVE_PHENOTYPE_FILTER
 export const SET_GENE_NETWORK_SCORES = '__SET_GENE_NETWORK_SCORES__'
 export const REMOVE_GENE_NETWORK_SCORES = '__REMOVE_GENE_NETWORK_SCORES__'
 export const UPDATE_VARIANT_SCORES = '__UPDATE_VARIANT_SCORES__'
+export const CLEAR_GENE_NETWORK_SCORES = '__CLEAR_GENE_NETWORK_SCORES__'
 
 export default {
   /**
@@ -144,9 +145,18 @@ export default {
    * Remove geneNetwork scores for a specific phenotypeId. Updates scores in the Variant table
    *
    * @param state state of the application
-   * @param phenotypeId Id of the filter that was removed
+   * @param removedPhenotypeFilter Id of the filter that was removed
    */
   [REMOVE_GENE_NETWORK_SCORES] (state, removedPhenotypeFilter) {
     delete state.geneNetworkScores[removedPhenotypeFilter.id]
+  },
+  /**
+   * Clear out the network scores
+   *
+   * @param state state of the application
+   */
+  [CLEAR_GENE_NETWORK_SCORES] (state) {
+    state.geneNetworkScores = {}
   }
+
 }

--- a/gene-network/src/main/frontend/test/unit/specs/components/HpoSelect.spec.js
+++ b/gene-network/src/main/frontend/test/unit/specs/components/HpoSelect.spec.js
@@ -1,0 +1,32 @@
+import HpoSelect from 'components/HpoSelect.vue'
+
+describe('HpoSelect', () => {
+  describe('when created', () => {
+    it('should use "hpo-select" as name', () => {
+      expect(HpoSelect.name).to.equal('hpo-select')
+    })
+
+    it('should set the correct default data', () => {
+      expect(typeof HpoSelect.data).to.equal('function')
+      const defaultData = HpoSelect.data()
+      expect(defaultData.phenotypes).to.eql([])
+      expect(defaultData.selectedOptions).to.eql([])
+    })
+  })
+
+  describe('when selectionChanged', () => {
+    it('should clear the store when called with empty filter', () => {
+      HpoSelect.methods.$store = {
+        state: {
+          phenotypeFilters: []
+        },
+        dispatch: sinon.spy(),
+        commit: sinon.spy()
+      }
+
+      HpoSelect.methods.selectionChanged([])
+      HpoSelect.methods.$store.commit.should.have.been.calledWith('__CLEAR_GENE_NETWORK_SCORES__')
+      HpoSelect.methods.$store.commit.should.have.been.calledWith('__UPDATE_VARIANT_SCORES__')
+    })
+  })
+})

--- a/gene-network/src/main/frontend/test/unit/specs/components/PhenotypeSelectionContainer.spec.js
+++ b/gene-network/src/main/frontend/test/unit/specs/components/PhenotypeSelectionContainer.spec.js
@@ -1,0 +1,33 @@
+import PhenotypeSelectionContainer from 'components/PhenotypeSelectionContainer.vue'
+
+describe('PhenotypeSelectionContainer', () => {
+  describe('when created', () => {
+    it('should use "hpo-select" as name', () => {
+      expect(PhenotypeSelectionContainer.name).to.equal('phenotype-selection-container')
+    })
+  })
+
+  describe('sortVariants', () => {
+    it('should sort by name if totalScore is missing', () => {
+      const a = {
+        Gene_Name: 'aaa'
+      }
+      const b = {
+        Gene_Name: 'bbb'
+      }
+      const result = PhenotypeSelectionContainer.methods.sortVariants(a, b)
+      expect(result).to.equal(1)
+    })
+
+    it('should sort by score if totalScore is defined', () => {
+      const a = {
+        totalScore: 4
+      }
+      const b = {
+        totalScore: 2
+      }
+      const result = PhenotypeSelectionContainer.methods.sortVariants(a, b)
+      expect(result).to.equal(-2)
+    })
+  })
+})

--- a/gene-network/src/main/frontend/test/unit/specs/mutations.spec.js
+++ b/gene-network/src/main/frontend/test/unit/specs/mutations.spec.js
@@ -360,4 +360,22 @@ describe('mutations', () => {
       expect(state.geneNetworkScores).to.deep.equal(geneNetworkScores)
     })
   })
+
+  describe('The CLEAR_GENE_NETWORK_SCORES mutation', () => {
+    it('should remove all scores', () => {
+      const state = {
+        geneNetworkScores: {
+          HP_0001249: {
+            BRCA1: 1.234
+          },
+          HP_0100280: {
+            BRCA1: 1.123
+          }
+        }
+      }
+      mutations.__CLEAR_GENE_NETWORK_SCORES__(state)
+      const emptyScore = {}
+      expect(state.geneNetworkScores).to.deep.equal(emptyScore)
+    })
+  })
 })


### PR DESCRIPTION
The selected phenotypes and phenotype options should be reset when the route changes. The gene network score should also recalculated. 